### PR TITLE
FreakySwitch: Added customization options for animation duration, thumb size in the…

### DIFF
--- a/.github/workflows/main_cd.yml
+++ b/.github/workflows/main_cd.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Verify commit exists in origin/main
+      - name: Verify commit exists in origin/master
         run: |
           git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
           git branch --remote --contains | grep origin/master
@@ -22,8 +22,8 @@ jobs:
           $version="${{github.ref_name}}".TrimStart("v")
           "version-without-v=$version" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
       - name: Pack
-        run: dotnet pack ~/MAUI.FreakyControls/MAUI.FreakyControls/Maui.FreakyControls.csproj -c Release -p:PackageVersion=${{ steps.get_version.outputs.version-without-v }}
+        run: dotnet pack MAUI.FreakyControls\MAUI.FreakyControls\Maui.FreakyControls.csproj -c Release -p:PackageVersion=${{ steps.get_version.outputs.version-without-v }}
       - name: Push
-        run: dotnet nuget push MAUI.FreakyControls/MAUI.FreakyControls/bin/Release/FreakyControls.${{ steps.get_version.outputs.version-without-v }}.nupkg -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_API_KEY }}
+        run: dotnet nuget push MAUI.FreakyControls\MAUI.FreakyControls\bin\Release\FreakyControls.${{ steps.get_version.outputs.version-without-v }}.nupkg -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_API_KEY }}
         env:
           GITHUB_TOKEN: ${{ secrets.NUGET_API_KEY }}


### PR DESCRIPTION
Added customization options for: animation duration, thumb size in the off state, and a check mark in the on state. Example of use:

```
<freaky:FreakySwitch AnimationDuration="30" 
                         ThumbOffSizeFactor="0.67"                         
                         ShowCheckMark="True"
                         CheckMarkWidth="3"
                         CheckMarkColor="Purple"/>
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced FreakySwitch control with customizable animation duration
	- Added optional checkmark display for switch state
	- Introduced new configuration properties for thumb size and appearance

- **Improvements**
	- More flexible switch control with advanced visual customization options
	- Dynamic animation timing for smoother state transitions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->