### PR TITLE
Create close-old-issues.yml

### DIFF
--- a/.github/workflows/close-old-issues.yml
+++ b/.github/workflows/close-old-issues.yml
@@ -1,0 +1,22 @@
+name: Close inactive issues
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v5
+        with:
+          days-before-issue-stale: 60
+          days-before-issue-close: 30
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue is stale because it has been open for 60 days with no activity."
+          close-issue-message: "This issue was closed because it has been inactive for 30 days since being marked as stale."
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Implemented automated housekeeping for issue tracking. Inactive issues are labeled “stale” after 60 days without activity and automatically closed 30 days later if still inactive.
  - The process runs daily and applies only to issues; pull requests are excluded.
  - Users will see status comments when an issue is marked stale and when it’s closed, improving visibility and keeping the tracker focused on active items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->